### PR TITLE
[Add] 새로운 방식으로 apollo local state 다루기, LoggedOutRouter, LogIn Form UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2335,6 +2335,11 @@
         "@types/node": "*"
       }
     },
+    "@types/history": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.9.tgz",
+      "integrity": "sha512-MUc6zSmU3tEVnkQ78q0peeEjKWPUADMlC/t++2bI8WnAG2tvYRPIgHG8lWkXwqc8MsUF6Z2MOf+Mh5sazOmhiQ=="
+    },
     "@types/html-minifier-terser": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz",
@@ -2426,6 +2431,25 @@
       "integrity": "sha512-wIvGxLfgpVDSAMH5utdL9Ngm5Owu0VsGmldro3ORLXV8CShrL8awVj06NuEXFQ5xyaYfdca7Sgbk/50Ri1GdPg==",
       "requires": {
         "@types/react": "*"
+      }
+    },
+    "@types/react-router": {
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.16.tgz",
+      "integrity": "sha512-8d7nR/fNSqlTFGHti0R3F9WwIertOaaA1UEB8/jr5l5mDMOs4CidEgvvYMw4ivqrBK+vtVLxyTj2P+Pr/dtgzg==",
+      "requires": {
+        "@types/history": "*",
+        "@types/react": "*"
+      }
+    },
+    "@types/react-router-dom": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.1.8.tgz",
+      "integrity": "sha512-03xHyncBzG0PmDmf8pf3rehtjY0NpUj7TIN46FrT5n1ZWHPZvXz32gUyNboJ+xsL8cpg8bQVLcllptcQHvocrw==",
+      "requires": {
+        "@types/history": "*",
+        "@types/react": "*",
+        "@types/react-router": "*"
       }
     },
     "@types/resolve": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14453,6 +14453,11 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
     },
+    "react-hook-form": {
+      "version": "7.11.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.11.1.tgz",
+      "integrity": "sha512-lBt428oU03dNUF5qZy5xqEdANaH3L/ilKWQS2t8wD6zF7FypOv46kEkZmg+oHf3n2xgeGYJgbMIGtYExsfKJ8A=="
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "postcss": "^8.3.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-hook-form": "^7.11.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
     "tailwindcss": "^2.2.4",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/node": "^12.20.16",
     "@types/react": "^17.0.14",
     "@types/react-dom": "^17.0.9",
+    "@types/react-router-dom": "^5.1.8",
     "autoprefixer": "^10.3.1",
     "graphql": "^15.5.1",
     "postcss": "^8.3.5",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,11 @@
-import { useQuery } from '@apollo/client';
-import gql from 'graphql-tag';
+import { useReactiveVar } from '@apollo/client';
 import React from 'react';
+import { isLoggedInVar } from './apollo';
 import { LoggedInRouter } from './routers/logged-in-router';
 import { LoggedOutRouter } from './routers/logged-out-router';
 
-const IS_LOGGED_IN = gql`
-  query isLoggedIn {
-    isLoggedIn @client
-  }
-`;
-
 function App() {
-  const {
-    data: { isLoggedIn },
-  } = useQuery(IS_LOGGED_IN);
+  const isLoggedIn = useReactiveVar(isLoggedInVar);
   console.log(isLoggedIn);
   return <>{isLoggedIn ? <LoggedInRouter /> : <LoggedOutRouter />}</>;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,11 @@
 import { useReactiveVar } from '@apollo/client';
 import React from 'react';
 import { isLoggedInVar } from './apollo';
-import { LoggedInRouter } from './routers/logged-in-router';
+import LoggedInRouter from './routers/logged-in-router';
 import { LoggedOutRouter } from './routers/logged-out-router';
 
 function App() {
   const isLoggedIn = useReactiveVar(isLoggedInVar);
-  console.log(isLoggedIn);
   return <>{isLoggedIn ? <LoggedInRouter /> : <LoggedOutRouter />}</>;
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,21 @@
+import { useQuery } from '@apollo/client';
+import gql from 'graphql-tag';
 import React from 'react';
 import { LoggedInRouter } from './routers/logged-in-router';
 import { LoggedOutRouter } from './routers/logged-out-router';
 
+const IS_LOGGED_IN = gql`
+  query isLoggedIn {
+    isLoggedIn @client
+  }
+`;
+
 function App() {
-  return (
-    <>
-    <LoggedOutRouter />
-    <LoggedInRouter />
-    </>
-  );
+  const {
+    data: { isLoggedIn },
+  } = useQuery(IS_LOGGED_IN);
+  console.log(isLoggedIn);
+  return <>{isLoggedIn ? <LoggedInRouter /> : <LoggedOutRouter />}</>;
 }
 
 export default App;

--- a/src/apollo.ts
+++ b/src/apollo.ts
@@ -1,8 +1,21 @@
-import { ApolloClient, InMemoryCache } from '@apollo/client';
+import { ApolloClient, InMemoryCache, makeVar } from '@apollo/client';
+
+export const isLoggedInVar = makeVar(false);
 
 // Initialize Apollo Client
 export const client = new ApolloClient({
   uri: 'http://localhost:4000/graphql',
-  cache: new InMemoryCache()
+  cache: new InMemoryCache({
+    typePolicies: {
+      Query: {
+        fields: {
+          isLoggedIn: {
+            read() {
+              return isLoggedInVar();
+            },
+          },
+        },
+      },
+    },
+  }),
 });
-

--- a/src/pages/create-account.tsx
+++ b/src/pages/create-account.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function CreateAccount() {
+  return <div></div>;
+}

--- a/src/pages/create-account.tsx
+++ b/src/pages/create-account.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
 
 export default function CreateAccount() {
-  return <div></div>;
+  return <div>create account</div>;
 }

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const Login = () => {
+  return <div>login</div>;
+};

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
 
 export const Login = () => {
-  return <div>login</div>;
+  return <div>Log In</div>;
 };

--- a/src/routers/logged-in-router.tsx
+++ b/src/routers/logged-in-router.tsx
@@ -1,1 +1,15 @@
-export const LoggedInRouter = () => <span>Logged In</span>
+import React from 'react';
+import { isLoggedInVar } from '../apollo';
+
+export default function LoggedInRouter() {
+  const onClick = () => {
+    isLoggedInVar(false);
+  };
+
+  return (
+    <div>
+      <h1>Logged In</h1>
+      <button onClick={onClick}>Log Out</button>
+    </div>
+  );
+}

--- a/src/routers/logged-out-router.tsx
+++ b/src/routers/logged-out-router.tsx
@@ -1,1 +1,15 @@
-export const LoggedOutRouter = () => <span>Logged Out</span>
+import { isLoggedInVar } from '../apollo';
+
+export const LoggedOutRouter = () => {
+  const onClick = () => {
+    isLoggedInVar(true);
+    console.log('..');
+  };
+
+  return (
+    <div>
+      <h1>Logged out</h1>
+      <button onClick={onClick}>Click to login</button>
+    </div>
+  );
+};

--- a/src/routers/logged-out-router.tsx
+++ b/src/routers/logged-out-router.tsx
@@ -1,15 +1,64 @@
-import { isLoggedInVar } from '../apollo';
+import { useForm } from 'react-hook-form';
+
+interface IForm {
+  email: string;
+  password: string;
+}
 
 export const LoggedOutRouter = () => {
-  const onClick = () => {
-    isLoggedInVar(true);
-    console.log('..');
+  const {
+    register,
+    watch,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<IForm>();
+
+  const onSubmit = () => {
+    console.log(watch());
+  };
+  const onInvalid = () => {
+    console.log('cant create account');
+    console.log(errors);
   };
 
   return (
     <div>
       <h1>Logged out</h1>
-      <button onClick={onClick}>Click to login</button>
+      <form onSubmit={handleSubmit(onSubmit, onInvalid)}>
+        <div>
+          <input
+            {...register('email', {
+              required: true,
+              pattern: /^[A-Za-z0-9._$+=]+gmail.com$/,
+            })}
+            type="email"
+            name="email"
+            required
+            placeholder="email"
+          />
+          {errors.email?.message && (
+            <span className="bg-yellow-200">{errors.email.message}</span>
+          )}
+
+          {errors.email?.type === 'pattern' && (
+            <span className="red">Only gmail allowed</span>
+          )}
+        </div>
+        <div>
+          <input
+            {...register('password', {
+              required: true,
+            })}
+            type="password"
+            name="password"
+            required
+            placeholder="password"
+          />
+        </div>
+        <button type="submit" className="bg-yellow-100 text-white">
+          Submit
+        </button>
+      </form>
     </div>
   );
 };

--- a/src/routers/logged-out-router.tsx
+++ b/src/routers/logged-out-router.tsx
@@ -1,64 +1,18 @@
-import { useForm } from 'react-hook-form';
-
-interface IForm {
-  email: string;
-  password: string;
-}
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+import CreateAccount from '../pages/create-account';
+import { Login } from '../pages/login';
 
 export const LoggedOutRouter = () => {
-  const {
-    register,
-    watch,
-    handleSubmit,
-    formState: { errors },
-  } = useForm<IForm>();
-
-  const onSubmit = () => {
-    console.log(watch());
-  };
-  const onInvalid = () => {
-    console.log('cant create account');
-    console.log(errors);
-  };
-
   return (
-    <div>
-      <h1>Logged out</h1>
-      <form onSubmit={handleSubmit(onSubmit, onInvalid)}>
-        <div>
-          <input
-            {...register('email', {
-              required: true,
-              pattern: /^[A-Za-z0-9._$+=]+gmail.com$/,
-            })}
-            type="email"
-            name="email"
-            required
-            placeholder="email"
-          />
-          {errors.email?.message && (
-            <span className="bg-yellow-200">{errors.email.message}</span>
-          )}
-
-          {errors.email?.type === 'pattern' && (
-            <span className="red">Only gmail allowed</span>
-          )}
-        </div>
-        <div>
-          <input
-            {...register('password', {
-              required: true,
-            })}
-            type="password"
-            name="password"
-            required
-            placeholder="password"
-          />
-        </div>
-        <button type="submit" className="bg-yellow-100 text-white">
-          Submit
-        </button>
-      </form>
-    </div>
+    <Router>
+      <Switch>
+        <Route path="/create-account">
+          <CreateAccount />
+        </Route>
+        <Route path="/login">
+          <Login />
+        </Route>
+      </Switch>
+    </Router>
   );
 };


### PR DESCRIPTION
- makeVar, useReactiveVar 메서드를 통해 apolloclient에 local state를 생성할 수 있다.
- 기존에는 gql태그로 선언방식이 다소 난잡했으나 위 두 메서드 덕분에 간편해짐(v3부터 생김)
- apollo Client에 생성하는 LocalState는 apolloServer의 Field와는 연관되지 않음
   -  (사실상 전역 스테이트 관리(리덕스 or mobx)의 하나의 방식으로 훨씬 쉽게 사용 가능할 듯)
 
- react-hook-form 라이브러리는 최고 .. 😎
- tailwind-css @apply 적용이 안되면 package.json 커맨드와 관련해서 업데이트 된 것이 있는지 확인 필요