### PR TITLE
[Add] 테스트케이스 > category , pages폴더 전체 (렌더용 컴포넌트 제외)

### DIFF
--- a/src/pages/__test__/404.spec.tsx
+++ b/src/pages/__test__/404.spec.tsx
@@ -1,18 +1,10 @@
-import { render, waitFor } from '@testing-library/react';
 import React from 'react';
-import { HelmetProvider } from 'react-helmet-async';
-import { BrowserRouter as Router } from 'react-router-dom';
+import { render, waitFor } from '../../test-utils';
 import { NotFound } from '../404';
 
 describe('<NotFound/>', () => {
   it('renders ok', async () => {
-    render(
-      <HelmetProvider>
-        <Router>
-          <NotFound />
-        </Router>
-      </HelmetProvider>
-    );
+    render(<NotFound />);
     await waitFor(() => {
       expect(document.title).toBe('Not Found | Newber Eats');
     });

--- a/src/pages/__test__/create-account.spec.tsx
+++ b/src/pages/__test__/create-account.spec.tsx
@@ -1,0 +1,125 @@
+import { ApolloProvider } from '@apollo/client';
+import userEvent from '@testing-library/user-event';
+import { createMockClient, MockApolloClient } from 'mock-apollo-client';
+import { render, RenderResult, waitFor } from '../../test-utils';
+import { UserRole } from '../../__generated__/globalTypes';
+import { CreateAccount, CREATE_ACCOUNT_MUTATION } from '../create-account';
+
+const mockPush = jest.fn();
+
+jest.mock('react-router-dom', () => {
+  //실제 모듈(라이브러리)의 모든것을 가져올 수 있게 된다.
+  const realModule = jest.requireActual('react-router-dom');
+
+  return {
+    ...realModule,
+    //아래와 같이 하나의 메서드만 모킹 해버리면 라이브러리 전체가 하나의 메서드만 가진애로 대체되기 때문에
+    // 그냥 다 고장나버린다(실제로 존재하는 모든걸 모킹할게 아니라면 ..)
+    // 그래서 realModule을 붙여주는 것이다.
+    useHistory: () => {
+      return {
+        push: mockPush,
+      };
+    },
+  };
+});
+
+describe('CreateAccount', () => {
+  let mockedClient: MockApolloClient;
+  let renderResult: RenderResult;
+
+  beforeEach(async () => {
+    await waitFor(() => {
+      mockedClient = createMockClient();
+      renderResult = render(
+        <ApolloProvider client={mockedClient}>
+          <CreateAccount />
+        </ApolloProvider>
+      );
+    });
+  });
+
+  it('renders ok', async () => {
+    await waitFor(() => {
+      expect(document.title).toBe('Create Account | Newber Eats');
+    });
+  });
+
+  it('renders validation Error', async () => {
+    const { getByRole, getByPlaceholderText } = renderResult;
+    const email = getByPlaceholderText(/email/i);
+    const password = getByPlaceholderText(/password/i);
+    const button = getByRole('button');
+
+    await waitFor(() => {
+      userEvent.type(email, 'email@worknot');
+    });
+    let errorMessage = getByRole('alert');
+    expect(errorMessage).toHaveTextContent('Please Enter a valid email');
+    await waitFor(() => {
+      userEvent.clear(email);
+    });
+
+    errorMessage = getByRole('alert');
+    expect(errorMessage).toHaveTextContent(/email is required/i);
+
+    await waitFor(() => {
+      userEvent.type(email, 'real@email.com');
+      userEvent.click(button);
+    });
+
+    errorMessage = getByRole('alert');
+    expect(errorMessage).toHaveTextContent(/password is required/i);
+  });
+
+  it('submits mutation with form values', async () => {
+    const { getByRole, getByPlaceholderText } = renderResult;
+    const email = getByPlaceholderText(/email/i);
+    const password = getByPlaceholderText(/password/i);
+    const button = getByRole('button');
+    const formData = {
+      email: 'working@email.com',
+      password: 'workingpassword',
+      role: UserRole.Client,
+    };
+
+    const mockedLoginMutationResponse = jest.fn().mockResolvedValue({
+      data: {
+        createAccount: {
+          ok: true,
+          error: 'mutation-error',
+        },
+      },
+    });
+
+    mockedClient.setRequestHandler(
+      CREATE_ACCOUNT_MUTATION,
+      mockedLoginMutationResponse
+    );
+
+    jest.spyOn(window, 'alert').mockImplementation(() => null);
+
+    await waitFor(() => {
+      userEvent.type(email, formData.email);
+      userEvent.type(password, formData.password);
+      userEvent.click(button);
+    });
+    expect(mockedLoginMutationResponse).toHaveBeenCalledTimes(1);
+    expect(mockedLoginMutationResponse).toHaveBeenLastCalledWith({
+      createAccountInput: {
+        email: formData.email,
+        password: formData.password,
+        role: formData.role,
+      },
+    });
+    expect(window.alert).toHaveBeenCalledWith('Account Created! Log in now!');
+    const mutationError = getByRole('alert');
+    expect(mockPush).toHaveBeenCalledWith('/');
+    expect(mutationError).toHaveTextContent('mutation-error');
+  });
+
+  afterAll(() => {
+    //모든 테스트가 끝나고 모킹한 모든것을 원상복귀 시키기 위함.
+    jest.clearAllMocks();
+  });
+});

--- a/src/pages/client/__test__/category.test.tsx
+++ b/src/pages/client/__test__/category.test.tsx
@@ -1,0 +1,76 @@
+import { MockedProvider } from '@apollo/client/testing';
+import { RenderResult, waitFor } from '@testing-library/react';
+import { render } from '../../../test-utils';
+import { Category, CATEGORY_QUERY } from '../category';
+
+describe('<Category />', () => {
+  let renderResult: RenderResult;
+
+  beforeEach(async () => {
+    await waitFor(async () => {
+      renderResult = render(
+        <MockedProvider
+          mocks={[
+            {
+              request: {
+                query: CATEGORY_QUERY,
+                variables: {
+                  input: {
+                    page: 1,
+                    slug: 'slug',
+                  },
+                },
+              },
+              result: {
+                data: {
+                  category: {
+                    ok: true,
+                    errror: null,
+                    totalPages: 1,
+                    totalResults: 1,
+                    restaurants: [
+                      {
+                        __typename: 'Restaurant',
+                        id: 1,
+                        name: 'test-restaurant',
+                        coverImg: 'test-coverimg-url',
+                        category: 'test-category-name',
+                        address: 'test-address',
+                        isPromoted: true,
+                      },
+                    ],
+                    category: {
+                      __typename: 'Category',
+                      id: 1,
+                      name: 'test-category-name',
+                      coverImg: 'test-img-url',
+                      slug: 'slug',
+                      restaurantCount: 1,
+                    },
+                  },
+                },
+              },
+            },
+          ]}
+        >
+          <Category />
+        </MockedProvider>
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  });
+
+  test('renders ok', async () => {
+    await waitFor(() => {
+      expect(document.title).toBe('Category Search | NewberEats');
+    });
+  });
+
+  test('data is only one , link length is 1', async () => {
+    const { getByText, debug } = renderResult;
+    await waitFor(() => {
+      debug();
+    });
+  });
+});

--- a/src/pages/client/category.tsx
+++ b/src/pages/client/category.tsx
@@ -1,6 +1,6 @@
-import { useLazyQuery } from '@apollo/client';
+import { useQuery } from '@apollo/client';
 import gql from 'graphql-tag';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router';
 import CategoryLink from '../../components/category-link';
@@ -11,7 +11,7 @@ import { category, categoryVariables } from '../../__generated__/category';
 import { CategoryParts } from '../../__generated__/CategoryParts';
 import { RestaurantParts } from '../../__generated__/RestaurantParts';
 
-const CATEGORY_QUERY = gql`
+export const CATEGORY_QUERY = gql`
   query category($input: CategoryInput!) {
     category(input: $input) {
       ok
@@ -39,25 +39,32 @@ export const Category = () => {
   const params = useParams<ICategoryParams>();
   const [page, setPage] = useState(1);
 
-  const [queryReadyToStart, { data, loading, error }] = useLazyQuery<
-    category,
-    categoryVariables
-  >(CATEGORY_QUERY);
-
-  console.log(data);
-
-  useEffect(() => {
-    if (params.slug) {
-      queryReadyToStart({
-        variables: {
-          input: {
-            page,
-            slug: params.slug,
-          },
+  const { data, loading, error } = useQuery<category, categoryVariables>(
+    CATEGORY_QUERY,
+    {
+      variables: {
+        input: {
+          page,
+          slug: params.slug,
         },
-      });
+      },
     }
-  }, []);
+  );
+
+  console.log('data', data);
+
+  // useEffect(() => {
+  //   if (params.slug) {
+  //     queryReadyToStart({
+  //       variables: {
+  //         input: {
+  //           page,
+  //           slug: params.slug,
+  //         },
+  //       },
+  //     });
+  //   }
+  // }, []);
 
   const onNextPageClick = () => setPage((current) => current + 1);
   const onPrevPageClick = () => setPage((current) => current - 1);

--- a/src/pages/create-account.tsx
+++ b/src/pages/create-account.tsx
@@ -12,7 +12,7 @@ import {
 } from '../__generated__/createAccountMutation';
 import { UserRole } from '../__generated__/globalTypes';
 
-const CREATE_ACCOUNT_MUTATION = gql`
+export const CREATE_ACCOUNT_MUTATION = gql`
   mutation createAccountMutation($createAccountInput: CreateAccountInput!) {
     createAccount(input: $createAccountInput) {
       ok
@@ -26,7 +26,7 @@ interface ICreateAccountForm {
   role: UserRole;
 }
 
-const CreateAccount = () => {
+export const CreateAccount = () => {
   const {
     register,
     getValues,
@@ -115,7 +115,6 @@ const CreateAccount = () => {
           <input
             {...register('password', {
               required: 'Password is required',
-              minLength: 10,
             })}
             name="password"
             type="password"
@@ -131,11 +130,7 @@ const CreateAccount = () => {
           {errors.password?.message && (
             <FormError errorMessage={errors.password?.message} />
           )}
-          {errors.password?.type === 'minLength' && (
-            <span className="font-medium text-red-500">
-              <FormError errorMessage="Password must be more than 10 chars." />
-            </span>
-          )}
+
           <Button
             canClick={isValid}
             loading={loading}
@@ -157,5 +152,3 @@ const CreateAccount = () => {
     </div>
   );
 };
-
-export default CreateAccount;

--- a/src/routers/logged-out-router.tsx
+++ b/src/routers/logged-out-router.tsx
@@ -1,6 +1,6 @@
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import { NotFound } from '../pages/404';
-import CreateAccount from '../pages/create-account';
+import { CreateAccount } from '../pages/create-account';
 import { Login } from '../pages/login';
 
 export const LoggedOutRouter = () => {

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -1,0 +1,18 @@
+import { render } from '@testing-library/react';
+import { HelmetProvider } from 'react-helmet-async';
+import { BrowserRouter as Router } from 'react-router-dom';
+const AllTheProviders: React.FC = ({ children }) => {
+  return (
+    <HelmetProvider>
+      <Router>{children}</Router>
+    </HelmetProvider>
+  );
+};
+
+const cutomRender = (ui: React.ReactElement, options?: any) =>
+  render(ui, { wrapper: AllTheProviders, ...options });
+
+//re-export everything
+export * from '@testing-library/react';
+//override render method
+export { cutomRender as render };


### PR DESCRIPTION
- 특정라이브러리의 함수를 mocking하는 방법
- useLazyQuery에서 기존 useQuery와 같이 mock하는방법이 통하지 않아 임시로 category로직 변경
- test용 Render유틸을 별도 생성하면 반복적인 wrapper(ex. Router)를 만들지 않아도 됨
- 